### PR TITLE
Feat/university speciallecture scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ channel_config.json
 
 test.py
 mongo.py
+*.txt

--- a/utils/scraper_category.py
+++ b/utils/scraper_category.py
@@ -11,6 +11,7 @@ class ScraperCategory(Enum):
         [
             ScraperType.UNIVERSITY_ACADEMIC,
             ScraperType.UNIVERSITY_SCHOLARSHIP,
+            ScraperType.UNIVERSITY_SPECIALLECTURE,
         ],
     )
 

--- a/utils/scraper_type.py
+++ b/utils/scraper_type.py
@@ -126,6 +126,12 @@ class ScraperType(Enum):
         "https://law.kookmin.ac.kr/law/etc-board/notice01.do",
         "LawAcademicScraper",
     )
+    UNIVERSITY_SPECIALLECTURE = (
+        "university_speciallecture",
+        "대학 특강공지",
+        "https://cs.kookmin.ac.kr/news/kookmin/special_lecture/",
+        "UniversitySpeciallectureScraper",
+    )
 
     def get_collection_name(self) -> str:
         """MongoDB 컬렉션 이름을 반환합니다."""

--- a/web_scraper/university_speciallecture_scraper.py
+++ b/web_scraper/university_speciallecture_scraper.py
@@ -1,0 +1,55 @@
+from bs4 import BeautifulSoup
+from datetime import datetime
+from template.notice_data import NoticeData
+from utils.scraper_type import ScraperType
+from utils.web_scraper import WebScraper
+from config.logger_config import setup_logger
+
+logger = setup_logger(__name__)
+
+
+class UniversitySpeciallectureScraper(WebScraper):
+    """대학 특강공지 스크래퍼"""
+
+    def __init__(self, url: str):
+        super().__init__(url, ScraperType.UNIVERSITY_SPECIALLECTURE)
+
+    def get_list_elements(self, soup: BeautifulSoup) -> list:
+        """특강공지 목록의 HTML 요소들을 가져옵니다."""
+        # notice-bg(공지사항)와 normal-bg(일반 게시물) 모두 가져옴
+        elements = soup.select(".list-tbody .normal-bg, .list-tbody .notice-bg")
+        return elements if elements else []
+
+    async def parse_notice_from_element(self, element) -> NoticeData:
+        """HTML 요소에서 특강공지 정보를 추출합니다."""
+        try:
+            # 공지사항 여부 확인
+            is_notice = "notice-bg" in element.get("class", [])
+
+            # 제목과 링크 추출
+            title_tag = element.select_one(".subject a")
+            if not title_tag:
+                return None
+
+            title = title_tag.text.strip()
+            link = title_tag["href"]
+            if not link.startswith("http"):
+                link = f"https://cs.kookmin.ac.kr/news/kookmin/special_lecture/{link}"
+
+            # 날짜 추출
+            date = element.select_one(".date").text.strip()
+            published = datetime.strptime(date, "%Y-%m-%d").replace(tzinfo=self.kst)
+
+            # 공지사항인 경우 제목 앞에 [공지] 표시 추가
+            if is_notice and not title.startswith("[공지]"):
+                title = f"[공지] {title}"
+
+            return NoticeData(
+                title=title,
+                link=link,
+                published=published,
+                scraper_type=self.scraper_type,
+            )
+        except Exception as e:
+            logger.error(f"공지사항 파싱 중 오류: {e}")
+            return None


### PR DESCRIPTION
This pull request introduces a new scraper for university special lectures. The changes include updates to the scraper types and categories, as well as the addition of the new scraper class.

New scraper addition:

* [`utils/scraper_type.py`](diffhunk://#diff-688d2092579ed936a90a1179a95eadc49bc48fd17233f3676689211a1908c8c0R129-R134): Added `UNIVERSITY_SPECIALLECTURE` to the `ScraperType` enum.
* [`utils/scraper_category.py`](diffhunk://#diff-18e36eb99e3945d5db10b0e930c4b4363e3dd6a2affba55fd8462a6a52059335R14): Included `ScraperType.UNIVERSITY_SPECIALLECTURE` in the relevant category list.
* [`web_scraper/university_speciallecture_scraper.py`](diffhunk://#diff-c6e05921c1f28fd491ee403caac06a4467b79b9d3847fcc0dd82eed8071afc0dR1-R55): Created the `UniversitySpeciallectureScraper` class to handle scraping of university special lecture notices.