### PR TITLE
Fix: 관리자 권한 확인 시 응답 메시지 출력 방식 수정

### DIFF
--- a/discord_bot/commands/register.py
+++ b/discord_bot/commands/register.py
@@ -91,8 +91,8 @@ class RegisterView(discord.ui.View):
             else:
                 # 서버 채널인 경우 관리자 권한 확인
                 if not self.interaction.permissions.administrator:
-                    await self.interaction.response.send_message(
-                        "이 명령어는 관리자 권한이 필요합니다.", ephemeral=True
+                    await self.interaction.edit_original_response(
+                        content="❕ 이 명령어는 관리자 권한이 필요합니다."
                     )
                     return
                 channel_id = str(self.interaction.channel_id)


### PR DESCRIPTION
## ✅ 관리자 권한이 없을 때의 메시지 응답 방식 수정


### ❗️문제 상황

게시판 선택 명령어 실행 시, 관리자 권한이 없는 사용자가 실행하면 다음 메시지를 출력해야 합니다:

> “이 명령어는 관리자 권한이 필요합니다.”

하지만 기존 코드에서는 이 메시지를 `response.send_message()를`  통해,
즉 응답을 새로 생성하는 방식으로 출력하려다 보니 interaction 시 오류가 발생했습니다.

이에 따라 `response.send_message()` 대신 `edit_original_response()` 를 사용하여 응답을 변경하는 방식으로 수정하였습니다.

⸻

### 🔧 변경 내용 요약
- 변경 파일 : `discord_bot/commands/register.py`
- `response.send_message()` → `edit_original_response()`로 대체

⸻

### 🧪 테스트 결과
- 관리자 권한 없는 유저가 명령어를 실행하면 정상적으로 에러 메시지가 표시됩니다.

⸻

🔗 관련 이슈: #38